### PR TITLE
Redid the extract-auth-token.py script to allow for CLI variables as well as automation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *~
 __pycache__
+.DS_Store

--- a/examples/extract-auth-token.py
+++ b/examples/extract-auth-token.py
@@ -6,27 +6,43 @@ import json
 import sys
 import platform
 import os
+import getopt
 
-userdir = os.getlogin()
-useros = platform.system()
+def jankauto():
+    userdir = os.getlogin()
+    useros = platform.system()
 
-#darfileloc = f'/Users/{userdir}/Library/Application Support/AnkerMake/AnkerMake_64bit_fp/login.json'
-darfileloc = f'/Users/thomaspatterson/Library/Application Support/AnkerMake/AnkerMake_64bit_fp/login.json'
-winfileloc = os.path.join('C:\\Users\\') + f'{userdir}' + os.path.join('\\AppData\\Local\\Ankermake\\login.json')
+    #darfileloc = f'/Users/{userdir}/Library/Application Support/AnkerMake/AnkerMake_64bit_fp/login.json'
+    darfileloc = f'/Users/thomaspatterson/Library/Application Support/AnkerMake/AnkerMake_64bit_fp/login.json'
+    winfileloc = os.path.join('C:\\Users\\') + f'{userdir}' + os.path.join('\\AppData\\Local\\Ankermake\\login.json')
+    
+    try:
+        opts, args = getopt.getopt(sys.argv[1:],"haf:", ["help", "auto", "file="])
+    except getopt.GetoptError:
+      print ('extract-auth-token.py -a OR extract-auth-token.py -f <path-to-login.json>')
+      sys.exit(2)
 
-if useros == 'Darwin':
-    data = open(f'{darfileloc}').read()
-    json = json.loads(libflagship.logincache.decrypt(data))
-    print(json["data"]["auth_token"])
-    exit(1)
-elif useros == 'Windows':
-    data = open(f'{winfileloc}').read()
-    json = json.loads(libflagship.logincache.decrypt(data))
-    print(json["data"]["auth_token"])
-    exit(1)
-elif len(sys.argv) != 2:
-    print(f"usage: {sys.argv[0]} <path/to/login.json>")
-    data = open(sys.argv[1]).read()
-    json = json.loads(libflagship.logincache.decrypt(data))
-    print(json["data"]["auth_token"])
-    exit(1)
+    for opt, arg in opts: 
+        if opt == '-h':
+            print ('extract-auth-token.py -a OR extract-auth-token.py -f <path-to-login.json> \nIf spaces are in file location remember to escape them with a backslash')
+            exit(1)
+        elif opt in ("-f", "--file"):
+            data = open(arg).read()
+            jsonj = json.loads(libflagship.logincache.decrypt(data))
+            print(jsonj["data"]["auth_token"])
+            exit(1)
+        elif opt in ("-a", "--auto"):
+            if useros == 'Darwin':
+                data = open(f'{darfileloc}').read()
+                jsonj = json.loads(libflagship.logincache.decrypt(data))
+                print(jsonj["data"]["auth_token"])
+                exit(1)
+            elif useros == 'Windows':
+                data = open(f'{winfileloc}').read()
+                jsonj = json.loads(libflagship.logincache.decrypt(data))
+                print(jsonj["data"]["auth_token"])
+                exit(1)
+        else:
+            assert False, "unhandled option"
+
+jankauto()

--- a/examples/extract-auth-token.py
+++ b/examples/extract-auth-token.py
@@ -4,12 +4,29 @@ from libflagship.util import b64d
 import libflagship.logincache
 import json
 import sys
+import platform
+import os
 
-if len(sys.argv) != 2:
-    print(f"usage: {sys.argv[0]} <path/to/login.json>")
+userdir = os.getlogin()
+useros = platform.system()
+
+#darfileloc = f'/Users/{userdir}/Library/Application Support/AnkerMake/AnkerMake_64bit_fp/login.json'
+darfileloc = f'/Users/thomaspatterson/Library/Application Support/AnkerMake/AnkerMake_64bit_fp/login.json'
+winfileloc = os.path.join('C:\\Users\\') + f'{userdir}' + os.path.join('\\AppData\\Local\\Ankermake\\login.json')
+
+if useros == 'Darwin':
+    data = open(f'{darfileloc}').read()
+    json = json.loads(libflagship.logincache.decrypt(data))
+    print(json["data"]["auth_token"])
     exit(1)
-
-data = open(sys.argv[1]).read()
-
-json = json.loads(libflagship.logincache.decrypt(data))
-print(json["data"]["auth_token"])
+elif useros == 'Windows':
+    data = open(f'{winfileloc}').read()
+    json = json.loads(libflagship.logincache.decrypt(data))
+    print(json["data"]["auth_token"])
+    exit(1)
+elif len(sys.argv) != 2:
+    print(f"usage: {sys.argv[0]} <path/to/login.json>")
+    data = open(sys.argv[1]).read()
+    json = json.loads(libflagship.logincache.decrypt(data))
+    print(json["data"]["auth_token"])
+    exit(1)


### PR DESCRIPTION
Added cli flags of -h (--help), -f (--file), and -a (--auto). Help displays correct syntax. Auto will attempt to detect your OS and then execute the script. File you will need to put in the correct path for it to correctly grab your auth token.