### PR TITLE
Enhancing the extract-auth-token.py script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *~
 __pycache__
+.DS_Store

--- a/examples/extract-auth-token.py
+++ b/examples/extract-auth-token.py
@@ -6,27 +6,43 @@ import json
 import sys
 import platform
 import os
+import getopt
 
-userdir = os.getlogin()
-useros = platform.system()
+def jankauto():
+    userdir = os.getlogin()
+    useros = platform.system()
 
-#darfileloc = f'/Users/{userdir}/Library/Application Support/AnkerMake/AnkerMake_64bit_fp/login.json'
-darfileloc = f'/Users/thomaspatterson/Library/Application Support/AnkerMake/AnkerMake_64bit_fp/login.json'
-winfileloc = os.path.join('C:\\Users\\') + f'{userdir}' + os.path.join('\\AppData\\Local\\Ankermake\\login.json')
+    #darfileloc = f'/Users/{userdir}/Library/Application Support/AnkerMake/AnkerMake_64bit_fp/login.json'
+    darfileloc = f'/Users/thomaspatterson/Library/Application Support/AnkerMake/AnkerMake_64bit_fp/login.json'
+    winfileloc = os.path.join('C:\\Users\\') + f'{userdir}' + os.path.join('\\AppData\\Local\\Ankermake\\login.json')
+    
+    try:
+        opts, args = getopt.getopt(sys.argv[1:],"haf:", ["help", "auto", "file="])
+    except getopt.GetoptError:
+      print ('extract-auth-token.py -a OR extract-auth-token.py -f <path-to-login.json>')
+      sys.exit(2)
 
-if useros == 'Darwin':
-    data = open(f'{darfileloc}').read()
-    json = json.loads(libflagship.logincache.decrypt(data))
-    print(json["data"]["auth_token"])
-    exit(1)
-elif useros == 'Windows':
-    data = open(f'{winfileloc}').read()
-    json = json.loads(libflagship.logincache.decrypt(data))
-    print(json["data"]["auth_token"])
-    exit(1)
-elif len(sys.argv) != 2:
-    print(f"usage: {sys.argv[0]} <path/to/login.json>")
-    data = open(sys.argv[1]).read()
-    json = json.loads(libflagship.logincache.decrypt(data))
-    print(json["data"]["auth_token"])
-    exit(1)
+    for opt, arg in opts: 
+        if opt == '-h':
+            print ('extract-auth-token.py -a OR extract-auth-token.py -f <path-to-login.json> \nIf spaces are in file location remember to escape them with a backslash')
+            exit(1)
+        elif opt in ("-f", "--file"):
+            data = open(arg).read()
+            jsonj = json.loads(libflagship.logincache.decrypt(data))
+            print(jsonj["data"]["auth_token"])
+            exit(1)
+        elif opt in ("-a", "--auto"):
+            if useros == 'Darwin':
+                data = open(f'{darfileloc}').read()
+                jsonj = json.loads(libflagship.logincache.decrypt(data))
+                print(jsonj["data"]["auth_token"])
+                exit(1)
+            elif useros == 'Windows':
+                data = open(f'{winfileloc}').read()
+                jsonj = json.loads(libflagship.logincache.decrypt(data))
+                print(jsonj["data"]["auth_token"])
+                exit(1)
+        else:
+            assert False, "unhandled option"
+
+jankauto()

--- a/examples/extract-auth-token.py
+++ b/examples/extract-auth-token.py
@@ -12,8 +12,7 @@ def jankauto():
     userdir = os.getlogin()
     useros = platform.system()
 
-    #darfileloc = f'/Users/{userdir}/Library/Application Support/AnkerMake/AnkerMake_64bit_fp/login.json'
-    darfileloc = f'/Users/thomaspatterson/Library/Application Support/AnkerMake/AnkerMake_64bit_fp/login.json'
+    darfileloc = f'/Users/{userdir}/Library/Application Support/AnkerMake/AnkerMake_64bit_fp/login.json'
     winfileloc = os.path.join('C:\\Users\\') + f'{userdir}' + os.path.join('\\AppData\\Local\\Ankermake\\login.json')
     
     try:

--- a/examples/extract-auth-token.py
+++ b/examples/extract-auth-token.py
@@ -8,40 +8,38 @@ import platform
 import os
 import getopt
 
-def jankauto():
+def print_login(filename):
+    data = open(filename).read()
+    jsonj = json.loads(libflagship.logincache.decrypt(data))
+    print(jsonj["data"]["auth_token"])
+
+def main():
     userdir = os.getlogin()
     useros = platform.system()
 
     darfileloc = f'/Users/{userdir}/Library/Application Support/AnkerMake/AnkerMake_64bit_fp/login.json'
-    winfileloc = os.path.join('C:\\Users\\') + f'{userdir}' + os.path.join('\\AppData\\Local\\Ankermake\\login.json')
+    winfileloc = os.path.expandvars(r'%APPDATA%\Local\Ankermake\login.json')
     
     try:
         opts, args = getopt.getopt(sys.argv[1:],"haf:", ["help", "auto", "file="])
     except getopt.GetoptError:
       print ('extract-auth-token.py -a OR extract-auth-token.py -f <path-to-login.json>')
-      sys.exit(2)
+      return 2
 
     for opt, arg in opts: 
         if opt == '-h':
             print ('extract-auth-token.py -a OR extract-auth-token.py -f <path-to-login.json> \nIf spaces are in file location remember to escape them with a backslash')
-            exit(1)
+            return(1)
         elif opt in ("-f", "--file"):
-            data = open(arg).read()
-            jsonj = json.loads(libflagship.logincache.decrypt(data))
-            print(jsonj["data"]["auth_token"])
-            exit(1)
+            print_login(arg)
         elif opt in ("-a", "--auto"):
             if useros == 'Darwin':
-                data = open(f'{darfileloc}').read()
-                jsonj = json.loads(libflagship.logincache.decrypt(data))
-                print(jsonj["data"]["auth_token"])
-                exit(1)
+                print_login({darfileloc})
             elif useros == 'Windows':
-                data = open(f'{winfileloc}').read()
-                jsonj = json.loads(libflagship.logincache.decrypt(data))
-                print(jsonj["data"]["auth_token"])
-                exit(1)
+                print_login({winfileloc})
         else:
-            assert False, "unhandled option"
+            print ("extract-auth-token.py -a OR extract-auth-token.py -f <path-to-login.json>")
+            return 1
 
-jankauto()
+if __name__ == "__main__":
+    exit(main())

--- a/examples/extract-auth-token.py
+++ b/examples/extract-auth-token.py
@@ -34,12 +34,13 @@ def main():
             print_login(arg)
         elif opt in ("-a", "--auto"):
             if useros == 'Darwin':
-                print_login({darfileloc})
+                print_login(darfileloc)
             elif useros == 'Windows':
-                print_login({winfileloc})
+                print_login(winfileloc)
         else:
             print ("extract-auth-token.py -a OR extract-auth-token.py -f <path-to-login.json>")
             return 1
 
 if __name__ == "__main__":
     exit(main())
+    

--- a/examples/extract-auth-token.py
+++ b/examples/extract-auth-token.py
@@ -4,12 +4,29 @@ from libflagship.util import b64d
 import libflagship.logincache
 import json
 import sys
+import platform
+import os
 
-if len(sys.argv) != 2:
-    print(f"usage: {sys.argv[0]} <path/to/login.json>")
+userdir = os.getlogin()
+useros = platform.system()
+
+#darfileloc = f'/Users/{userdir}/Library/Application Support/AnkerMake/AnkerMake_64bit_fp/login.json'
+darfileloc = f'/Users/thomaspatterson/Library/Application Support/AnkerMake/AnkerMake_64bit_fp/login.json'
+winfileloc = os.path.join('C:\\Users\\') + f'{userdir}' + os.path.join('\\AppData\\Local\\Ankermake\\login.json')
+
+if useros == 'Darwin':
+    data = open(f'{darfileloc}').read()
+    json = json.loads(libflagship.logincache.decrypt(data))
+    print(json["data"]["auth_token"])
     exit(1)
-
-data = open(sys.argv[1]).read()
-
-json = json.loads(libflagship.logincache.decrypt(data))
-print(json["data"]["auth_token"])
+elif useros == 'Windows':
+    data = open(f'{winfileloc}').read()
+    json = json.loads(libflagship.logincache.decrypt(data))
+    print(json["data"]["auth_token"])
+    exit(1)
+elif len(sys.argv) != 2:
+    print(f"usage: {sys.argv[0]} <path/to/login.json>")
+    data = open(sys.argv[1]).read()
+    json = json.loads(libflagship.logincache.decrypt(data))
+    print(json["data"]["auth_token"])
+    exit(1)

--- a/examples/extract-auth-token.py
+++ b/examples/extract-auth-token.py
@@ -5,7 +5,7 @@ import libflagship.logincache
 import json
 import sys
 import platform
-import os
+from os import path
 import getopt
 
 def print_login(filename):
@@ -14,11 +14,10 @@ def print_login(filename):
     print(jsonj["data"]["auth_token"])
 
 def main():
-    userdir = os.getlogin()
     useros = platform.system()
 
-    darfileloc = f'/Users/{userdir}/Library/Application Support/AnkerMake/AnkerMake_64bit_fp/login.json'
-    winfileloc = os.path.expandvars(r'%APPDATA%\Local\Ankermake\login.json')
+    darfileloc = path.expanduser('~/Library/Application Support/AnkerMake/AnkerMake_64bit_fp/login.json')
+    winfileloc = path.expandvars(r'%APPDATA%\Local\Ankermake\login.json')
     
     try:
         opts, args = getopt.getopt(sys.argv[1:],"haf:", ["help", "auto", "file="])
@@ -29,7 +28,7 @@ def main():
     for opt, arg in opts: 
         if opt == '-h':
             print ('extract-auth-token.py -a OR extract-auth-token.py -f <path-to-login.json> \nIf spaces are in file location remember to escape them with a backslash')
-            return(1)
+            return 1
         elif opt in ("-f", "--file"):
             print_login(arg)
         elif opt in ("-a", "--auto"):
@@ -43,4 +42,3 @@ def main():
 
 if __name__ == "__main__":
     exit(main())
-    


### PR DESCRIPTION
Added cli flags of -h (--help), -f (--file), and -a (--auto). Help displays correct syntax. Auto will attempt to detect your OS and then execute the script. File you will need to put in the correct path for it to correctly grab your auth token.