### PR TITLE
Add requirements.txt and fix pppp.py 

### DIFF
--- a/ankerctl.py
+++ b/ankerctl.py
@@ -17,7 +17,7 @@ from libflagship.util import unhex, enhex
 from libflagship.mqtt import MqttMsg, MqttMsgType
 from libflagship.pppp import PktLanSearch
 from libflagship.mqttapi import AnkerMQTTBaseClient
-from libflagship.ppppapi import AnkerPPPPApi
+# from libflagship.ppppapi import AnkerPPPPApi
 
 class AnkerMQTTClient(AnkerMQTTBaseClient):
 

--- a/ankerctl.py
+++ b/ankerctl.py
@@ -17,7 +17,7 @@ from libflagship.util import unhex, enhex
 from libflagship.mqtt import MqttMsg, MqttMsgType
 from libflagship.pppp import PktLanSearch
 from libflagship.mqttapi import AnkerMQTTBaseClient
-# from libflagship.ppppapi import AnkerPPPPApi
+from libflagship.ppppapi import AnkerPPPPApi
 
 class AnkerMQTTClient(AnkerMQTTBaseClient):
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+paho_mqtt==1.6.1
+pycryptodomex==3.17
+rich==13.3.1
+requests==2.28.2
+click==8.1.3
+platformdirs==3.1.1
+git+https://github.com/chrivers/transwarp.git


### PR DESCRIPTION
Fixes error:

```
./ankerctl.py
Traceback (most recent call last):
  File "/Users/<redacted>/Code/github/spuder/ankermake-m5-protocol/./ankerctl.py", line 23, in <module>
    from libflagship.pppp import AnkerPPPPApi
ImportError: cannot import name 'AnkerPPPPApi' from 'libflagship.pppp' (/Users/<redacted>/Code/github/spuder/ankermake-m5-protocol/libflagship/pppp.py)
```

Requirements.txt was taken from this branch https://github.com/Ankermgmt/ankermake-m5-protocol/pull/5/files and then added dependencies `click` and `platformdirs`