### PR TITLE
Add autodiscover to config decode

### DIFF
--- a/ankerctl.py
+++ b/ankerctl.py
@@ -148,12 +148,25 @@ def http_calc_sec_code(sn, mac):
 def config(): pass
 
 @config.command("decode")
-@click.argument("fd", required=True, type=click.File("r"), metavar="path/to/login.json")
+@click.argument("fd", required=False, type=click.File("r"), metavar="path/to/login.json")
 @pass_env
 def config_import(env, fd):
     """
     Decode a `login.json` file and print its contents.
     """
+
+    if fd is None:
+        useros = platform.system()
+
+        darfileloc = path.expanduser('~/Library/Application Support/AnkerMake/AnkerMake_64bit_fp/login.json')
+        winfileloc = path.expandvars(r'%LOCALAPPDATA%\Ankermake\AnkerMake_64bit_fp\login.json')
+
+        if useros == 'Darwin' and path.exists(darfileloc):
+            fd = open(darfileloc, 'r')
+        elif useros == 'Windows' and path.exists(winfileloc):
+            fd = open(winfileloc, 'r')
+        else:
+            exit("This platform does not support autodetection. Please specify file location")
 
     log.info("Loading file..")
 


### PR DESCRIPTION
Before
```
./ankerctl.py config decode
Usage: ankerctl.py config decode [OPTIONS] path/to/login.json
Try 'ankerctl.py config decode -h' for help.
```

After
```
 ./ankerctl.py config decode
[*] Loading file..
{
    'ab_code': 'US',
    REDACTED
```

Related to https://github.com/Ankermgmt/ankermake-m5-protocol/pull/8