### PR TITLE
Add crcmod

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ click==8.1.3
 platformdirs==3.1.1
 git+https://github.com/chrivers/transwarp.git
 tinyec==0.4.0
+crcmod==1.7


### PR DESCRIPTION
Explicitly define crcmod dependency. 

While 99% of users won't run into this. It is an edge case that can be hit when running from a completely fresh python environment. 

```
anker pppp lan-search
Traceback (most recent call last):
  File "/app/ankerctl.py", line 11, in <module>
    import cli.config
  File "/app/cli/config.py", line 3, in <module>
    from .model import Serialize, Account, Printer, Config
  File "/app/cli/model.py", line 4, in <module>
    from libflagship.util import unhex, enhex
  File "/app/libflagship/util.py", line 2, in <module>
    import crcmod
ModuleNotFoundError: No module named 'crcmod'
```