### PR TITLE
chrivers/faux-cephalopod

### DIFF
--- a/cli/util.py
+++ b/cli/util.py
@@ -1,5 +1,6 @@
 import click
 import json
+from flask import make_response, abort
 
 
 def json_key_value(str):
@@ -96,3 +97,18 @@ def split_chunks(data, chunksize):
         res.append(data[:chunksize])
         data = data[chunksize:]
     return res
+
+
+def parse_http_bool(str):
+    if str in {"true", "True", "1"}:
+        return True
+    elif str in {"false", "False", "0"}:
+        return False
+    else:
+        raise ValueError(f"Could not parse {str!r} as boolean")
+
+
+def http_abort(code, message):
+    response = make_response(f"{message}")
+    response.status_code = code
+    abort(response)

--- a/libflagship/ppppapi.py
+++ b/libflagship/ppppapi.py
@@ -49,6 +49,10 @@ class FileUploadInfo:
     @classmethod
     def from_file(cls, filename, user_name, user_id, machine_id, type=0):
         data = open(filename, "rb").read()
+        return cls(data, filename, user_name, user_id, machine_id, type=0)
+
+    @classmethod
+    def from_data(cls, data, filename, user_name, user_id, machine_id, type=0):
         return cls(
             name=cls.sanitize_filename(os.path.basename(filename)),
             size=len(data),

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ git+https://github.com/chrivers/transwarp.git
 tinyec==0.4.0
 crcmod==1.7
 tqdm==4.65.0
+flask==2.2.0


### PR DESCRIPTION
This PR brings rudimentary OctoPrint server emulation support to `ankerctl`.

Just run `ankerctl.py webserver run`, and follow the instructions at http://127.0.0.1:4470 to connect PrusaSlicer directly to `ankerctl`.

This allows direct printing from PrusaSlicer.