### PR TITLE
Webhelpfixes

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -23,7 +23,7 @@
 						<li class="list-group-item">Fill in "Descriptive name for the printer" with whatever you like</li>
 						<li class="list-group-item">Select your Ankermake printer profile from the dropdown menu</li>
 						<li class="list-group-item">Under "Host Type" select "OctoPrint"</li>
-						<li class="list-group-item">In "Hostname, IP or URL" fill in with: <kbd>{{ configHost }}:{{ configPort }}</kbd>&nbsp;<a class="text-decoration-none" href="#" id="configData">📋</a></li>
+						<li class="list-group-item">In "Hostname, IP or URL" fill in with: <kbd>{{ configHost }}:{{ configPort }}</kbd>&nbsp;<a class="text-decoration-none" href="#" title="Copy to clipboard" id="configData">📋</a></li>
 						<li class="list-group-item">Leave "API Key / Password" blank</a></li>
 						<li class="list-group-item">Click "Test" to validate input</li>
 						<li class="list-group-item">Click "Ok" to close the window</li>

--- a/static/index.html
+++ b/static/index.html
@@ -22,16 +22,17 @@
 						<li class="list-group-item">Click "Gear"⚙️ (Add/Edit Physical Printer)</li>
 						<li class="list-group-item">Fill in "Descriptive name for the printer" with whatever you like</li>
 						<li class="list-group-item">Select your Ankermake printer profile from the dropdown menu</li>
-						<li class="list-group-item">Under "Host type" select "OctoPrint"</li>
-						<li class="list-group-item">In "Hostname, IP or URL" fill in with: <kbd>{{ configHost }}:{{ configPort }}</kbd><a class="text-decoration-none" href="#" id="configData"> 📋</a></li>
+						<li class="list-group-item">Under "Host Type" select "OctoPrint"</li>
+						<li class="list-group-item">In "Hostname, IP or URL" fill in with: <kbd>{{ configHost }}:{{ configPort }}</kbd>&nbsp;<a class="text-decoration-none" href="#" id="configData">📋</a></li>
 						<li class="list-group-item">Leave "API Key / Password" blank</a></li>
 						<li class="list-group-item">Click "Test" to validate input</li>
-						<li class="list-group-item">Click "Ok"</li>
-						<li class="list-group-item">Go and slice yor files</li>
-						<li class="list-group-item">Press "G&#x3E;" button to start direct upload</li>
-						<li class="list-group-item">Press "Upload and print" - the "Upload"-only is not supported</li>
+						<li class="list-group-item">Click "Ok" to close the window</li>
+						<li class="list-group-item">Slice your file as normal</li>
+						<li class="list-group-item">Click "G&#x3E;" button to start direct upload to the printer</li>
+						<li class="list-group-item">Click "Upload and print" - the "Upload"-only is not supported</li>
 						<li class="list-group-item">Enjoy printing with ankerctl 😉</li>
 					</ol>
+					<br><span class="fw-light">Hint: <kbd>Ctrl+Shift+G</kbd> will slice and open the upload to printer window</span>
 				</div>
 				<div class="col-12 col-lg-12 text-center">
 					<img src="/static/img/setup/prusaslicer-1.png" class="img-thumbnail" alt="step 1">

--- a/static/index.html
+++ b/static/index.html
@@ -41,7 +41,6 @@
 					<img src="/static/img/setup/prusaslicer-4.png" class="img-thumbnail mt-2" alt="step 4">
 				</div>
 			</div>
-			{{ configData }}
 		</div>
 		<script src="/static/vendor/bootstrap-5.3.0-alpha3-dist/js/bootstrap.bundle.min.js"></script>
 		<script src="/static/vendor/cash.min.js"></script>


### PR DESCRIPTION
Fixed spelling error in "slice yor files"
Adding spacing the clipboard link and added title to improve usability
Exlained upload directly a bit more
Removed configData leftover template tag
Added hint about shortcut buttons - don't know the keys for Mac but guessing CMD+Shitft+G but awaiting testing when my macbook is back