### PR TITLE
Add pipeline to publish docker container and release

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -1,0 +1,92 @@
+name: Docker Image CI
+
+on:
+  push:
+    tags:
+     - v**
+  pull_request:
+    branches: [ master ]
+     
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
+      
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+      with:
+        submodules: recursive
+      
+    - name: Log into registry ${{ env.REGISTRY }}
+      if: github.event_name == 'push'
+      uses: docker/login-action@v2.1.0
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Docker Setup QEMU
+      uses: docker/setup-qemu-action@v2.1.0
+      
+    - name: Docker Setup Buildx
+      uses: docker/setup-buildx-action@v2.5.0
+      with:
+        version: latest
+        install: true
+        
+    - name: Docker Metadata action
+      id: meta
+      if: github.event_name == 'push'
+      uses: docker/metadata-action@v4.3.0
+      with:
+        images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+        flavor: |
+          latest=${{ github.event_name == 'push' }}
+        tags: ${{ github.ref_name }}
+        
+    - name: Build and push Docker images
+      uses: docker/build-push-action@v4.0.0
+      with:
+        context: .
+        file: Dockerfile
+        platforms: linux/arm/v7,linux/arm64,linux/amd64
+        push: ${{ github.event_name == 'push' }}
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}
+    
+    - name: Create release directory
+      run: mkdir release
+      
+    - name: Zip Release
+      if: github.event_name == 'push'
+      uses: TheDoctor0/zip-release@0.7.1
+      with:
+        type: 'zip'
+        filename: release/ankerctl.zip
+        exclusions: '*.git* release'
+        
+    - name: GZip Release
+      if: github.event_name == 'push'
+      uses: TheDoctor0/zip-release@0.7.1
+      with:
+        type: 'tar'
+        filename: release/ankerctl.tar.gz
+        exclusions: '*.git* release'
+        
+    - name: Release
+      if: ${{ github.event_name == 'push' }}
+      uses: docker://antonyurchenko/git-release:v5.0.1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        args: |
+          release/ankerctl.zip
+          release/ankerctl.tar.gz
+  

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -69,15 +69,15 @@ jobs:
       uses: TheDoctor0/zip-release@0.7.1
       with:
         type: 'zip'
-        filename: release/ankerctl.zip
-        exclusions: '*.git* release'
+        filename: release/ankerctl-${{ github.ref_name }}.zip
+        exclusions: '*.git* /*release/*'
         
     - name: GZip Release
       if: github.event_name == 'push'
       uses: TheDoctor0/zip-release@0.7.1
       with:
         type: 'tar'
-        filename: release/ankerctl.tar.gz
+        filename: release/ankerctl-${{ github.ref_name }}.tar.gz
         exclusions: '*.git* release'
         
     - name: Release
@@ -86,7 +86,5 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        args: |
-          release/ankerctl.zip
-          release/ankerctl.tar.gz
+        args: release/ankerctl*
   

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.0.0] - 2023-04-07
+


### PR DESCRIPTION
on tag, this pipeline will build a docker container for common architectures (amd64, 32-bit arm, 64-bit arm) and zip up the repo as a .zip file and a .tar.gz file

the zip step is arguably not any different from the default source code zip files that are attached to a release by default, but may be useful placeholders for any kind of build steps that produce os specific packages.

How to use:
As you push changes, or new features, update CHANGELOG.md for the version that's under development, or under the Unreleased header. At some point before creating and pushing a new tag, push this changelog with the next version number as a section with all of the changes for that release. The contents of this header become the release notes.

edit CHANGELOG.md
`git add CHANGELOG.md`
`git commit -m "whatevs" `
`git push`

`git tag v1.2.3`
`git push origin v1.2.3`
