### PR TITLE
Docker improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,4 +28,5 @@ COPY cli /app/cli/
 # Copy the installed dependencies from the build environment
 COPY --from=build-env /usr/local/lib/python3.11/site-packages /usr/local/lib/python3.11/site-packages
 
-ENTRYPOINT ["python", "/app/ankerctl.py"]
+ENTRYPOINT ["/app/ankerctl.py"]
+CMD ["webserver", "run"]

--- a/ankerctl.py
+++ b/ankerctl.py
@@ -458,7 +458,7 @@ app = Flask(__name__, template_folder='./static')
 
 @app.get("/")
 def app_root():
-    return render_template("index.html", configPort = app.config["port"], configHost = app.config["host"])
+    return render_template("index.html", requestPort = request.host.split(':')[1], requestHost = request.host.split(':')[0])
 
 @app.get("/api/version")
 def app_api_version():

--- a/ankerctl.py
+++ b/ankerctl.py
@@ -458,7 +458,9 @@ app = Flask(__name__, template_folder='./static')
 
 @app.get("/")
 def app_root():
-    return render_template("index.html", requestPort = request.host.split(':')[1], requestHost = request.host.split(':')[0])
+    host = request.host.split(':')
+    requestPort = host[1] if len(host) > 1 else '80'
+    return render_template("index.html", requestPort = requestPort, requestHost = host[0])
 
 @app.get("/api/version")
 def app_api_version():

--- a/ankerctl.py
+++ b/ankerctl.py
@@ -459,7 +459,7 @@ app = Flask(__name__, template_folder='./static')
 @app.get("/")
 def app_root():
     host = request.host.split(':')
-    requestPort = host[1] if len(host) > 1 else '80'
+    requestPort = host[1] if len(host) > 1 else '80' # If there is no 2nd array entry, the request port is 80
     return render_template("index.html", requestPort = requestPort, requestHost = host[0])
 
 @app.get("/api/version")

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,7 +10,6 @@ services:
     image: ankerctl/ankerctl:latest
     container_name: ankerctl
     restart: unless-stopped
-    pull_policy: build
     build: .
     environment:
       - FLASK_PORT=4470

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,4 +1,4 @@
-version: '3.9'
+version: '3.9.1'
 
 # You must manually run `ankerctl config import` atleast once
 # docker run \
@@ -10,6 +10,7 @@ services:
     image: ankerctl/ankerctl:latest
     container_name: ankerctl
     restart: unless-stopped
+    pull_policy: build
     build: .
     environment:
       - FLASK_PORT=4470

--- a/static/index.html
+++ b/static/index.html
@@ -23,7 +23,7 @@
 						<li class="list-group-item">Fill in "Descriptive name for the printer" with whatever you like</li>
 						<li class="list-group-item">Select your Ankermake printer profile from the dropdown menu</li>
 						<li class="list-group-item">Under "Host Type" select "OctoPrint"</li>
-						<li class="list-group-item">In "Hostname, IP or URL" fill in with: <kbd>{{ configHost }}:{{ configPort }}</kbd>&nbsp;<a class="text-decoration-none" href="#" title="Copy to clipboard" id="configData">📋</a></li>
+						<li class="list-group-item">In "Hostname, IP or URL" fill in with: <kbd>{{ requestHost }}:{{ requestPort }}</kbd>&nbsp;<a class="text-decoration-none" href="#" title="Copy to clipboard" id="configData">📋</a></li>
 						<li class="list-group-item">Leave "API Key / Password" blank</a></li>
 						<li class="list-group-item">Click "Test" to validate input</li>
 						<li class="list-group-item">Click "Ok" to close the window</li>
@@ -47,7 +47,7 @@
 		<script>
 			$(function () {
 				$('#configData').on('click',function(){
-					navigator.clipboard.writeText("{{ configHost }}:{{ configPort }}");
+					navigator.clipboard.writeText("{{ requestHost }}:{{ requestPort }}");
 					return false;
 				})
 			});


### PR DESCRIPTION
### Description

Improves a few areas for running as a Docker container:

1. Adds a `CMD` statement to the Dockerfile so that unattended docker deployments (such as through Portainer [or any 3rd party Docker manager]) don't automatically fail due to an invalid command.
2. Changes `configHost` and `configPort` to `requestHost` and `requestPort` and updates how these values are populated. This now permits displaying the IP address and port of the request in the web interface instead of `0.0.0.0:4470` when using `FLASK_HOST=0.0.0.0`. 

### Testing
I tested these changes by building the docker image using Portainer and deploying it to my Synology NAS

#### Webserver view
![image](https://user-images.githubusercontent.com/3013565/230881501-c84b3da4-0d5b-48b5-a1f4-7c6d05bbdd19.png)

#### Print success
<img width="305" alt="image" src="https://user-images.githubusercontent.com/3013565/230881883-82cc84d1-2357-4b43-9532-2fb91623d526.png">

#### Container
![image](https://user-images.githubusercontent.com/3013565/230881990-0b292480-00b1-4adb-9a3a-5ea09712cd62.png)
