### PR TITLE
Added printing of the printers ip-address when using lan-search.

### DIFF
--- a/ankerctl.py
+++ b/ankerctl.py
@@ -217,7 +217,7 @@ def pppp_lan_search(env):
         log.error("No printers responded within timeout. Are you connected to the same network as the printer?")
     else:
         if isinstance(resp, libflagship.pppp.PktPunchPkt):
-            log.info(f"Printer [{str(resp.duid)}] is online")
+            log.info(f"Printer [{str(resp.duid)}] is online at {str(api.addr[0])}")
 
 
 @pppp.command("print-file")


### PR DESCRIPTION
When using the lan-search command it would be useful to know he ip-address of the printer. Added printing the ip-address of the packet we received from the printer.