### PR TITLE
Fixing issues with building docker image

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,4 +7,4 @@
 *.md    text
 *.txt   text
 *.tpl   text
-*.py    text diff=python
+*.py    text diff=python eol=lf

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ RUN mkdir -p /root/.config/
 # Copy the script and libraries
 COPY ankerctl.py /app/
 COPY web /app/web/
+COPY ssl /app/ssl/
 COPY static /app/static/
 COPY libflagship /app/libflagship/
 COPY cli /app/cli/

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,6 @@ RUN mkdir -p /root/.config/
 # Copy the script and libraries
 COPY ankerctl.py /app/
 COPY web /app/web/
-COPY ssl /app/ssl/
 COPY static /app/static/
 COPY libflagship /app/libflagship/
 COPY cli /app/cli/

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,4 +1,4 @@
-version: '3.9.1'
+version: "3.9.1"
 
 # You must manually run `ankerctl config import` atleast once
 # docker run \
@@ -6,21 +6,21 @@ version: '3.9.1'
 # -v "$HOME/Library/Application Support/AnkerMake/AnkerMake_64bit_fp/login.json:/tmp/login.json" \
 # ankerctl config import /tmp/login.json
 services:
-  ankerctl:
-    image: ankerctl/ankerctl:latest
-    container_name: ankerctl
-    restart: unless-stopped
-    build: .
-    environment:
-      - FLASK_PORT=4470
-      - FLASK_HOST=0.0.0.0
-    volumes:
-      - ankerctl_vol:/root/.config/ankerctl
-    ports:
-      - 127.0.0.1:4470:4470
-    entrypoint: "/app/ankerctl.py"
-    command: ["webserver", "run"]
+    ankerctl:
+        image: ankerctl/ankerctl:latest
+        container_name: ankerctl
+        restart: unless-stopped
+        build: .
+        environment:
+            - FLASK_PORT=4470
+            - FLASK_HOST=0.0.0.0
+        volumes:
+            - ankerctl_vol:/root/.config/ankerctl
+        ports:
+            - 127.0.0.1:4470:4470
+        working_dir: /app
+        entrypoint: "/app/ankerctl.py"
+        command: ["webserver", "run"]
 
 volumes:
-  ankerctl_vol:
-    external: true
+    ankerctl_vol:


### PR DESCRIPTION
### Description
* Fixing issues with building docker image on windows
* Removing the external volume indication since config can be uploaded from web now
* Set the working_dir in Dockercompose to /app

Prettier buried the lead on `docker-compose.yaml`, actual changes were: 
```diff
services:
  ankerctl:
    image: ankerctl/ankerctl:latest
    container_name: ankerctl
    restart: unless-stopped
    build: .
    environment:
      - FLASK_PORT=4470
      - FLASK_HOST=0.0.0.0
    volumes:
      - ankerctl_vol:/root/.config/ankerctl
    ports:
      - 127.0.0.1:4470:4470
+   working_dir: /app
    entrypoint: "/app/ankerctl.py"
    command: ["webserver", "run"]

volumes:
  ankerctl_vol:
-   external: true
```