### PR TITLE
Cleanup Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ RUN mkdir -p /root/.config/
 # Copy the script and libraries
 COPY ankerctl.py /app/
 COPY static /app/static/
+COPY web /app/web/
 COPY libflagship /app/libflagship/
 COPY cli /app/cli/
 
@@ -29,4 +30,3 @@ COPY cli /app/cli/
 COPY --from=build-env /usr/local/lib/python3.11/site-packages /usr/local/lib/python3.11/site-packages
 
 ENTRYPOINT ["/app/ankerctl.py"]
-CMD ["webserver", "run"]


### PR DESCRIPTION
Add web directory to the Dockerfile to fix issue 

`ModuleNotFoundError: No module named 'web'`

Remove CMD from Dockerfile, since `ankerctl` has many options and its probabably best to not force a user to use a single option (its a lot easier to opt-in to a CMD than it is to opt Out of a CMD)

The docker-compose not the dockerfile should be the opinionated source regarding which parameter should be run. 

```
    entrypoint: "/app/ankerctl.py"
    command: ["webserver", "run"]
```