### PR TITLE
V1.0.0 documentation mac install

### DIFF
--- a/documentation/install-from-docker.md
+++ b/documentation/install-from-docker.md
@@ -45,7 +45,16 @@
 
 1. Install the [AnkerMake slicer](https://www.ankermake.com/software). Make sure you open it and login via the “Account” dropdown in the top toolbar.
    	**NOTE:** The slicer app does not need to be open for the rest of these steps.
-2. 
+
+2. Install Docker Desktop that matches your CPU by following [this guide](https://docs.docker.com/desktop/install/mac-install/) (supplemental steps are provided below).
+
+    It is strongly recommended that if your are using a Mac with Apple Silicon to install Rosetta 2. It is no longer a requirement since Docker 4.3.0 however for the best experience it should be installed. The easiest way to install it is via your preferred choice of Terminal and running this command:
+      
+      `softwareupdate --install-rosetta`
+  
+     - [ ] **[<u>Install Docker Desktop</u>]** Download and install Docker Desktop using the linked docker docs guide. Once the install process is complete, open Docker Desktop and accept the EULA. You can close Docker Desktop for the remaining steps.
+
+3. Download the latest version of ankerctl from the GitHub releases page and extract the contents wherever you would like to run the program from.
 
 ## Linux (UNDER CONSTRUCTION)
 

--- a/documentation/install-from-docker.md
+++ b/documentation/install-from-docker.md
@@ -56,6 +56,15 @@
 
 3. Download the latest version of ankerctl from the GitHub releases page and extract the contents wherever you would like to run the program from.
 
+4. The next steps will take place in your preferred choice of Terminal.
+
+   4a. Navigate to the ankerctl directory (i.e.: cd \Users\username\Downloads\ankerctl if you unzipped it in your Downloads folder)
+   4b. Run the following command to build the docker container(s) and volume(s) needed by ankerctl.
+
+      `docker compose build`
+      
+5. Upon completion of the build, you can view within the Docker Desktop that it is in fact running by going to the Containers section of Docker Desktop and see "ankerctl" running. You may have to click the arrow next to the container name to view "ankerctl". You can also click on "4470:4470" on that screen if you would like to launch your browser to the webserver page. 
+
 ## Linux (UNDER CONSTRUCTION)
 
 1. Install the [AnkerMake slicer](https://www.ankermake.com/software). Make sure you open it and login via the “Account” dropdown in the top toolbar.

--- a/documentation/install-from-docker.md
+++ b/documentation/install-from-docker.md
@@ -39,7 +39,7 @@
 
 5. Run the following command to build the docker container(s) and volume(s) needed by ankerctl.
 
-   `docker compose build`
+   `docker compose up`
 
 ## MacOS (UNDER CONSTRUCTION)
 
@@ -58,10 +58,10 @@
 
 4. The next steps will take place in your preferred choice of Terminal.
 
-   4a. Navigate to the ankerctl directory (i.e.: cd \Users\username\Downloads\ankerctl if you unzipped it in your Downloads folder)
+   4a. Navigate to the ankerctl directory (i.e.: cd $HOME/Downloads or cd ~/Downloads if you unzipped it in your Downloads folder)
    4b. Run the following command to build the docker container(s) and volume(s) needed by ankerctl.
 
-      `docker compose build`
+      `docker compose up`
       
 5. Upon completion of the build, you can view within the Docker Desktop that it is in fact running by going to the Containers section of Docker Desktop and see "ankerctl" running. You may have to click the arrow next to the container name to view "ankerctl". You can also click on "4470:4470" on that screen if you would like to launch your browser to the webserver page. 
 


### PR DESCRIPTION
I added the Mac instructions for the Docker install. Thankfully even though there are two types of hardware the install process is the same except for the Rosetta 2 piece I highlighted in bullet 2. Please review and if you don't see any issues lets get it into your main documentation branch. 