### PR TITLE
Import login.json automatically in docker compose

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,26 +1,55 @@
-version: '3.9.1'
+version: "3.9.1"
 
-# You must manually run `ankerctl config import` atleast once
-# docker run \
-# -v ankerctl_vol:/root/.config/ankerctl \
-# -v "$HOME/Library/Application Support/AnkerMake/AnkerMake_64bit_fp/login.json:/tmp/login.json" \
-# ankerctl config import /tmp/login.json
 services:
-  ankerctl:
-    image: ankerctl/ankerctl:latest
-    container_name: ankerctl
-    restart: unless-stopped
-    build: .
-    environment:
-      - FLASK_PORT=4470
-      - FLASK_HOST=0.0.0.0
-    volumes:
-      - ankerctl_vol:/root/.config/ankerctl
-    ports:
-      - 127.0.0.1:4470:4470
-    entrypoint: "/app/ankerctl.py"
-    command: ["webserver", "run"]
+    ankerctl_seed_mac:
+        image: busybox
+        container_name: ankerctl_seed_mac
+        restart: "no"
+        volumes:
+            - ankerctl_vol:/root/.config/ankerctl
+            - "$HOME/Library/Application Support/AnkerMake/AnkerMake_64bit_fp/login.json:/tmp/login.json"
+        command: sh -c "cp /tmp/login.json /root/.config/ankerctl/login.json || true"
+    ankerctl_seed_linux:
+        image: busybox
+        container_name: ankerctl_seed_linux
+        restart: "no"
+        volumes:
+            - ankerctl_vol:/root/.config/ankerctl
+            # - "$HOME/Library/Application Support/AnkerMake/AnkerMake_64bit_fp/login.json:/tmp/login.json" #TODO: Change to linux path
+        command: sh -c "cp /tmp/login.json /root/.config/ankerctl/login.json || true"
+    ankerctl_import:
+        image: ankerctl/ankerctl:latest
+        container_name: ankerctl_import
+        restart: "no"
+        volumes:
+            - ankerctl_vol:/root/.config/ankerctl
+            - "$HOME/Library/Application Support/AnkerMake/AnkerMake_64bit_fp/login.json:/tmp/login.json"
+        entrypoint: "/app/ankerctl.py"
+        command: ["config", "import", "/tmp/login.json"]
+        depends_on:
+            - ankerctl_seed_mac
+            - ankerctl_seed_linux
+        
+    ankerctl:
+        image: ankerctl/ankerctl:latest
+        container_name: ankerctl
+        restart: unless-stopped
+        build: .
+        environment:
+            - FLASK_PORT=4470
+            - FLASK_HOST=0.0.0.0
+        volumes:
+            - ankerctl_vol:/root/.config/ankerctl
+        ports:
+            - 127.0.0.1:4470:4470
+        working_dir: /app
+        entrypoint: "/app/ankerctl.py"
+        command: ["webserver", "run"]
+        depends_on:
+            - ankerctl_seed_mac
+            - ankerctl_seed_linux
+            - ankerctl_import
 
 volumes:
   ankerctl_vol:
-    external: true
+    driver: internal


### PR DESCRIPTION
Solves the problem that was discussed in the Discord which I think will make everyone happy 😄 

Problem 1: Improve user experience so they only need to run 1 `docker compose` command (instead of 2) 
Problem 2: Attempt to automatically discover login.json on mac/linux machines, and if found import them. (Eliminating the need to manually import the config file in the gui. Users do not need to memorize `cmd+shift+g` or permenantly alter their ~/Library visibility settings)


## How it works

- Adds 3 new docker compose steps that ankerctl service depends on
( ankerctl_seed_mac, ankerctl_seed_linux, ankerctl_import)
- Attempt to bind mount to hard coded mac/linux paths for login.json
- Copies login.json to /tmp/login.json in the docker container
- runs `ankerctl config import` to copy the config to the docker volume
- All of these commands run with `|| true` to ignore any failures. Containers run with `restart: "no"` to happily continue if the import fails (falling back to the default behavior of manually importing config)


## Known issues / Compromises

This doesn't solve the issue where the config file has to be re-imported every time the container starts, however by automating the import as part of the startup, that is effectively a non-issue. 
