### PR TITLE
Add back docker compose version

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,3 +1,5 @@
+version: '3.9.1'
+
 services:
     ankerctl:
         image: ghcr.io/ankermgmt/ankermake-m5-protocol:latest


### PR DESCRIPTION
Docker compose defaults to version 1.0 if no version is defined. 

https://github.com/Ankermgmt/ankermake-m5-protocol/issues/116#issuecomment-1562760698