### PR TITLE
Adding Default Webcam Method

### DIFF
--- a/db.json
+++ b/db.json
@@ -1,0 +1,31 @@
+{
+    "announcements": {},
+    "gcode_metadata": {},
+    "history": {},
+    "mainsail": {
+        "dashboard": {
+            "nonExpandPanels": {
+                "widescreen": []
+            }
+        },
+        "gcodeViewer": {
+            "klipperCache": {
+                "axis_maximum": [
+                    235,
+                    235,
+                    250,
+                    0
+                ],
+                "axis_minimum": [
+                    -15,
+                    -15,
+                    -2,
+                    0
+                ]
+            }
+        }
+    },
+    "moonraker": {},
+    "update_manager": {},
+    "webcams": []
+}

--- a/web/moonraker/rpc/server/__init__.py
+++ b/web/moonraker/rpc/server/__init__.py
@@ -1,4 +1,5 @@
 from jsonrpc import dispatcher
+from flask import request
 from flask import current_app as app
 
 
@@ -228,7 +229,7 @@ def server_config():
                 "flip_h": False,
                 "flip_v": False,
                 "rotate_90": False,
-                "stream_url": "/webcam/?action=stream",
+                "stream_url": f"ws://{app.config['host']}:{app.config['port']}/ws/video",
                 "webcam_enabled": True
             },
             "history": {},
@@ -299,7 +300,7 @@ def server_config():
                 "password": "{secrets.mqtt_credentials.password}",
                 "enable_moonraker_api": True,
                 #                    "status_objects": "\nwebhooks\ntoolhead=position,print_time\nidle_timeout=state\ngcode_macro M118"
-                }
+            }
         },
         "files": [
             {
@@ -322,6 +323,40 @@ def server_config():
                 "sections": [
                     "mqtt"
                 ]
+            }
+        ]
+    }
+
+
+@dispatcher.add_method(name="server.webcams.list")
+def server_webcams_list():
+    if hasattr(request, "host"):
+        if ":" in request.host:
+            request_host, request_port = request.host.split(":", 1)
+        else:
+            request_host = request.host
+            request_port = "80"
+    else:
+        request_host = app.config["host"]
+        request_port = app.config["port"]
+
+    return {
+        "webcams": [
+            {
+                "name": "AnkerMake M5",
+                "location": "printer",
+                "service": "jmuxer-stream",
+                "enabled": True,
+                "icon": "mdiWebcam",
+                "target_fps": 15,
+                "target_fps_idle": 5,
+                "stream_url": f"ws://{request_host}:{request_port}/ws/video",
+                "snapshot_url": "",
+                "flip_horizontal": False,
+                "flip_vertical": False,
+                "rotation": 0,
+                "aspect_ratio": "4:3",
+                "source": "config"
             }
         ]
     }


### PR DESCRIPTION
### Description: 
* Adding in method for returning the default webcam to `moonraker.rpc.server` as `server.webcams.list`. See https://moonraker.readthedocs.io/en/latest/web_api/#list-webcams
* Populating db.json with default schema