### PR TITLE
Changing mqtt padding from zeros to bytes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 __pycache__
 .DS_Store
 /settings.json
+.vscode/

--- a/libflagship/mqtt.py
+++ b/libflagship/mqtt.py
@@ -89,7 +89,7 @@ class _MqttMsg:
     packet_num : u16le # maybe for fragmented messages?set to 1 for unfragmented messages.
     time       : u32le # `gettimeofday()` in whole seconds
     device_guid: bytes # device guid, as hex string
-    padding    : bytes = field(repr=False, kw_only=True, default='\x00' * 11) # padding bytes, allways zero
+    padding    : bytes # padding bytes, unknown usage
     data       : bytes # payload data
 
     @classmethod
@@ -105,7 +105,7 @@ class _MqttMsg:
         packet_num, p = u16le.parse(p)
         time, p = u32le.parse(p)
         device_guid, p = String.parse(p, 37)
-        padding, p = Zeroes.parse(p, 11)
+        padding, p = Bytes.parse(p, 11)
         data, p = Tail.parse(p)
         return cls(signature=signature, size=size, m3=m3, m4=m4, m5=m5, m6=m6, m7=m7, packet_type=packet_type, packet_num=packet_num, time=time, device_guid=device_guid, padding=padding, data=data), p
 
@@ -121,7 +121,7 @@ class _MqttMsg:
         p += u16le.pack(self.packet_num)
         p += u32le.pack(self.time)
         p += String.pack(self.device_guid, 37)
-        p += Zeroes.pack(self.padding, 11)
+        p += Bytes.pack(self.padding, 11)
         p += Tail.pack(self.data)
         return p
 

--- a/libflagship/mqttapi.py
+++ b/libflagship/mqttapi.py
@@ -51,7 +51,8 @@ class AnkerMQTTBaseClient:
         try:
             pkt, tail = MqttMsg.parse(msg.payload, key=self._key)
         except Exception as E:
-            log.error(f"Failed to decode mqtt message: {E}")
+            hexStr =' '.join([f'0x{byte:02x}' for byte in msg.payload])
+            log.error(f"Failed to decode mqtt message\n Exception: {E}\n Message : {hexStr}")
             return
 
         data = json.loads(pkt.data)

--- a/specification/mqtt.stf
+++ b/specification/mqtt.stf
@@ -50,8 +50,8 @@ struct _MqttMsg
     # device guid, as hex string
     device_guid: string<37>
 
-    # padding bytes, allways zero
-    padding:     zeroes<11>
+    # padding bytes, unknown usage
+    padding:     bytes<11>
 
     # payload data
     data: tail


### PR DESCRIPTION
Starting with the new firmware releases to anker make printers in the past few weeks, MQTT no longer connects. There is a field in the mqtt msg that expects 11 zeroes. these 11 bytes are no longer all zeroes. I switched the protocol to expect just bytes here since we did nothing with the zeroes to begin with this should be a backwards compatible change. 

Pasted below is a snippet from my terminal printing out the padding field. you'll see 2 bytes in the middle of the 11 that are no longer zeros.

```
[*] Padding: 0x0 0x0 0x0 0x3c 0x11 0x0 0x0 0x0 0x0 0x0 0x0
[*] Padding: 0x0 0x0 0x0 0x95 0x15 0x0 0x0 0x0 0x0 0x0 0x0
[*] Padding: 0x0 0x0 0x0 0xc6 0x20 0x0 0x0 0x0 0x0 0x0 0x0
[*] Padding: 0x0 0x0 0x0 0x5c 0x1d 0x0 0x0 0x0 0x0 0x0 0x0
[*] Padding: 0x0 0x0 0x0 0xa9 0x18 0x0 0x0 0x0 0x0 0x0 0x0
[*] Padding: 0x0 0x0 0x0 0xfa 0xf 0x0 0x0 0x0 0x0 0x0 0x0
[*] Padding: 0x0 0x0 0x0 0x99 0x21 0x0 0x0 0x0 0x0 0x0 0x0
[*] Padding: 0x0 0x0 0x0 0xd6 0x15 0x0 0x0 0x0 0x0 0x0 0x0
[*] Padding: 0x0 0x0 0x0 0x4c 0x9 0x0 0x0 0x0 0x0 0x0 0x0
[*] Padding: 0x0 0x0 0x0 0x3d 0x13 0x0 0x0 0x0 0x0 0x0 0x0
[*] Padding: 0x0 0x0 0x0 0xe3 0xb 0x0 0x0 0x0 0x0 0x0 0x0
```

Screenshot showing all green on the web ui after my change
<img width="1036" alt="image" src="https://github.com/Ankermgmt/ankermake-m5-protocol/assets/22949655/9efce17f-a1e2-44cc-b2a7-1550c211a10c">
