### PR TITLE
Fix padding in mqttapi::make_mqtt_pkt

### DIFF
--- a/libflagship/mqttapi.py
+++ b/libflagship/mqttapi.py
@@ -115,6 +115,7 @@ class AnkerMQTTBaseClient:
             packet_num=0,
             time=0,
             device_guid=guid,
+            padding=(b"\x00" * 11),
             data=data,
         )
 


### PR DESCRIPTION
I tried sending gcode over mqtt and this errored out. even with this fix the printer doesnt respond to the gcode but maybe thats my user error. since we have no clue what this field does i think its fine to do what we were doing before the previous fix; send all zeros.