### PR TITLE
Add initial support for the AnkerMake M5C

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # AnkerMake M5 Protocol
 
-Welcome! This repository contains `ankerctl`, a command-line interface and web UI for monitoring, controlling and interfacing with AnkerMake M5 3D printers.
+Welcome! This repository contains `ankerctl`, a command-line interface and web UI for monitoring, controlling and interfacing with AnkerMake M5 and M5C 3D printers.
 
 **NOTE:** This is our first major release and while we have tested thoroughly there may be bugs. If you encounter one please open a [Github Issue](https://github.com/Ankermgmt/ankermake-m5-protocol/issues/new/choose)
 
-The `ankerctl` program uses [`libflagship`](documentation/developer-docs/libflagship.md), a library for communicating with the numerous different protocols required for connecting to an AnkerMake M5 printer. The `libflagship` library is also maintained in this repo, under [`libflagship/`](libflagship/).
+The `ankerctl` program uses [`libflagship`](documentation/developer-docs/libflagship.md), a library for communicating with the numerous different protocols required for connecting to an AnkerMake M5 or M5C printer. The `libflagship` library is also maintained in this repo, under [`libflagship/`](libflagship/).
 
 ![Screenshot of ankerctl](/documentation/web-interface.png "Screenshot of ankerctl web interface")
 
@@ -14,7 +14,7 @@ The `ankerctl` program uses [`libflagship`](documentation/developer-docs/libflag
 
  - Print directly from PrusaSlicer and its derivatives (SuperSlicer, Bamboo Studio, OrcaSlicer, etc.)
 
- - Connect to AnkerMake M5 and AnkerMake APIs without using closed-source Anker software.
+ - Connect to AnkerMake M5/M5C and AnkerMake APIs without using closed-source Anker software.
 
  - Send raw gcode commands to the printer (and see the response).
 
@@ -22,7 +22,7 @@ The `ankerctl` program uses [`libflagship`](documentation/developer-docs/libflag
 
  - Send print jobs (gcode files) to the printer.
 
- - Stream camera image/video to your computer.
+ - Stream camera image/video to your computer (AnkerMake M5 only).
 
  - Easily monitor print status.
 
@@ -177,7 +177,7 @@ Some examples:
 
 This project is **<u>NOT</u>** endorsed, affiliated with, or supported by AnkerMake. All information found herein is gathered entirely from reverse engineering using publicly available knowledge and resources.
 
-The goal of this project is to make the AnkerMake M5 usable and accessible using only Free and Open Source Software (FOSS).
+The goal of this project is to make the AnkerMake M5 and M5C usable and accessible using only Free and Open Source Software (FOSS).
 
 This project is [licensed under the GNU GPLv3](LICENSE), and copyright © 2023 Christian Iversen.
 

--- a/libflagship/mqttapi.py
+++ b/libflagship/mqttapi.py
@@ -51,7 +51,7 @@ class AnkerMQTTBaseClient:
         try:
             pkt, tail = MqttMsg.parse(msg.payload, key=self._key)
         except Exception as E:
-            hexStr =' '.join([f'0x{byte:02x}' for byte in msg.payload])
+            hexStr = ' '.join([f'0x{byte:02x}' for byte in msg.payload])
             log.error(f"Failed to decode mqtt message\n Exception: {E}\n Message : {hexStr}")
             return
 
@@ -111,10 +111,11 @@ class AnkerMQTTBaseClient:
             m5=2,
             m6=5,
             m7=ord('F'),
-            packet_type=MqttPktType.Single,
+            packet_type=packet_type,
             packet_num=0,
             time=0,
             device_guid=guid,
+            padding=b'', # fixed by .pack()
             data=data,
         )
 

--- a/static/ankersrv.js
+++ b/static/ankersrv.js
@@ -210,7 +210,7 @@ $(function () {
             $("#progress").text("0%");
             $("#nozzle-temp").text("0°C");
             $("#set-nozzle-temp").attr("value", "0°C");
-            $("#bed-temp").text("$0°C");
+            $("#bed-temp").text("0°C");
             $("#set-bed-temp").attr("value", "0°C");
             $("#print-speed").text("0mm/s");
             $("#print-layer").text("0 / 0");
@@ -223,7 +223,7 @@ $(function () {
     sockets.video = new AutoWebSocket({
         name: "Video socket",
         url: `ws://${location.host}/ws/video`,
-        badge: "#badge-pppp",
+        badge: "#badge-video",
         binary: true,
 
         open: function () {
@@ -265,13 +265,26 @@ $(function () {
         badge: "#badge-ctrl",
     });
 
+    sockets.pppp_state = new AutoWebSocket({
+        name: "PPPP socket",
+        url: `ws://${location.host}/ws/pppp-state`,
+        badge: "#badge-pppp",
+    });
+
     /* Only connect websockets if #player element exists in DOM (i.e., if we
      * have a configuration). Otherwise we are constantly trying to make
      * connections that will never succeed. */
-    if ($("#player").length) {
+    if ($("#badge-mqtt").length) {
         sockets.mqtt.connect();
-        sockets.video.connect();
+    }
+    if ($("#badge-ctrl").length) {
         sockets.ctrl.connect();
+    }
+    if ($("#badge-pppp").length) {
+        sockets.pppp_state.connect();
+    }
+    if ($("#player").length) {
+        sockets.video.connect();
     }
 
     /**

--- a/static/tabs/home.html
+++ b/static/tabs/home.html
@@ -7,6 +7,7 @@
     <div class="container">
         <div class="row g-3">
             <div class="col-md-12 col-lg-6 col-xl-8">
+                {% if video_supported %}
                 <!-- Video Container -->
                 <video
                     class="w-100 d-block rounded-3 bg-body-tertiary"
@@ -17,6 +18,16 @@
                     poster="{{ url_for('static', filename='img/load-screen.svg') }}"
                 >
                 </video>
+                {% else %}
+                <div class="card">
+                    <div class="card-body text-center">
+                        <p class="display-1">
+                            {{ macro.bi_icon("camera-video-off") }}
+                        </p>
+                        <p class="display-6">Camera not available</p>
+                    </div>
+                </div>
+                {% endif %}
             </div>
             <div class="col-md-12 col-lg-6 col-xl-4">
                 <div class="card">
@@ -30,9 +41,13 @@
                         </div>
                         <span id="badge-mqtt" class="badge">MQTT</span>
                         <span id="badge-pppp" class="badge">PPPP</span>
+                        {% if video_supported %}
+                        <span id="badge-video" class="badge">VIDEO</span>
+                        {% endif %}
                         <span id="badge-ctrl" class="badge">CTRL</span>
                     </div>
                     {% endif %}
+                    {% if video_supported %}
                     <div class="card-header fs-6">Video Controls</div>
                     <div class="card-body">
                         <div class="row g-3 mb-3">
@@ -60,6 +75,7 @@
                             </div>
                         </div>
                     </div>
+                    {% endif %}
                     <div class="card-header fs-6">Temperature</div>
                     <div class="card-body">
                         <div class="row g-3">

--- a/web/lib/service.py
+++ b/web/lib/service.py
@@ -6,6 +6,7 @@ from enum import Enum
 from threading import Thread, Event
 from datetime import datetime, timedelta
 from multiprocessing import Queue
+from queue import Empty
 
 
 class Holdoff:
@@ -352,13 +353,13 @@ class ServiceManager:
         finally:
             self.put(name)
 
-    def stream(self, name: str):
+    def stream(self, name: str, timeout: float=None):
         try:
             with self.borrow(name) as svc:
                 queue = Queue()
 
                 with svc.tap(lambda data: queue.put(data)):
                     while svc.state == RunState.Running:
-                        yield queue.get()
-        except (EOFError, OSError, ServiceStoppedError):
+                        yield queue.get(timeout=timeout)
+        except (EOFError, OSError, ServiceStoppedError, Empty):
             return

--- a/web/service/pppp.py
+++ b/web/service/pppp.py
@@ -70,7 +70,12 @@ class PPPPService(Service):
         except ConnectionResetError:
             raise ServiceRestartSignal()
 
-        if not msg or msg.type != Type.DRW:
+        if not msg:
+            return
+
+        if msg.type != Type.DRW:
+            # forward messages other than Type.DRW without further processing
+            self.notify((getattr(msg, "chan", None), msg))
             return
 
         ch = self._api.chans[msg.chan]


### PR DESCRIPTION
This PR fixes #137 and allows to monitor MQTT messages of the AnkerMake M5C on the command line as well as observe the printer status via the Web GUI. It is also possible to send print jobs from your slicer to the printer without using AnkerMake Slicer or Studio (see README.md). The M5's additional hardware is still expected to exist, therefore the Web GUI will still pretend to wait for a camera connection, for example. This will have to be fixed in the future.

Note that I was only able to test with my M5C but not with an M5 for unwanted side-effects.

Eventually, if this patch is confirmed by others to work fine, we should add some related information to the README file.