### PR TITLE
Support storing detected printer IP addresses

### DIFF
--- a/ankerctl.py
+++ b/ankerctl.py
@@ -222,11 +222,12 @@ def pppp_lan_search(env, store):
 
     Works by broadcasting a LAN_SEARCH packet, and waiting for a reply.
     """
-    found_printers = cli.pppp.pppp_find_printer_ip_addresses(dumpfile=env.pppp_dump)
-    if found_printers:
-        for duid, ip in found_printers.items():
-            log.info(f"Printer [{duid}] is online at {ip}")
-    else:
+    found_printers = dict()
+    for duid, ip in cli.pppp.pppp_find_printer_ip_addresses(dumpfile=env.pppp_dump):
+        log.info(f"Printer [{duid}] is online at {ip}")
+        found_printers[duid] = ip
+
+    if not found_printers:
         log.error("No printers responded within timeout. Are you connected to the same network as the printer?")
 
     # if requested, update stored printer IP addresses

--- a/ankerctl.py
+++ b/ankerctl.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 
-import time
 import json
 import click
 import platform
@@ -23,7 +22,7 @@ import libflagship.seccode
 
 from libflagship.util import enhex
 from libflagship.mqtt import MqttMsgType
-from libflagship.pppp import PktLanSearch, P2PCmdType, P2PSubCmdType, FileTransfer
+from libflagship.pppp import P2PCmdType, P2PSubCmdType, FileTransfer
 from libflagship.ppppapi import FileUploadInfo, PPPPError
 
 
@@ -215,7 +214,7 @@ def pppp(): pass
 
 
 @pppp.command("lan-search")
-@click.option("--store", "-n", is_flag=True, help="Store found IP address(es) in configuration file")
+@click.option("--store", "-s", is_flag=True, help="Store found IP address(es) in configuration file")
 @pass_env
 def pppp_lan_search(env, store):
     """
@@ -223,44 +222,17 @@ def pppp_lan_search(env, store):
 
     Works by broadcasting a LAN_SEARCH packet, and waiting for a reply.
     """
-    # broadcast a search packet to all printers on the network
-    api = cli.pppp.pppp_open_broadcast(dumpfile=env.pppp_dump)
-    api.send(PktLanSearch())
-
-    # collect replies from all available printers
-    found_printers = dict()
-    wait_time = 1.0      # wait 1.0 second for responses
-    timeout = time.monotonic() + wait_time
-    while wait_time > 0:
-        try:
-            resp = api.recv(timeout=wait_time)
-        except TimeoutError:
-            if not found_printers:
-                log.error("No printers responded within timeout. Are you connected to the same network as the printer?")
-        else:
-            if isinstance(resp, libflagship.pppp.PktPunchPkt):
-                duid_str = str(resp.duid)
-                found_printers[duid_str] = api.addr[0]
-                log.info(f"Printer [{duid_str}] is online at {str(api.addr[0])}")
-        wait_time = timeout - time.monotonic()
+    found_printers = cli.pppp.pppp_find_printer_ip_addresses(dumpfile=env.pppp_dump)
+    if found_printers:
+        for duid, ip in found_printers.items():
+            log.info(f"Printer [{duid}] is online at {ip}")
+    else:
+        log.error("No printers responded within timeout. Are you connected to the same network as the printer?")
 
     # if requested, update stored printer IP addresses
     if store and found_printers:
         log.info(f"Checking configured printer IP addresses:")
-        with env.config.modify() as cfg:
-            if not cfg or not cfg.printers:
-                log.error("No printers configured. Run 'config login' or 'config import' to populate.")
-                return
-            for p in cfg.printers:
-                prefix = f"  Printer [{p.p2p_duid}]:"
-                if p.p2p_duid in found_printers:
-                    if p.ip_addr != found_printers[p.p2p_duid]:
-                        log.info(f"{prefix} Updating IP address from {p.ip_addr} to {found_printers[p.p2p_duid]}")
-                        p.ip_addr = found_printers[p.p2p_duid]
-                    else:
-                        log.info(f"{prefix} IP address {p.ip_addr} is already up-to-date")
-                else:
-                    log.warning(f"{prefix} No network response received, check connection!")
+        cli.config.update_printer_ip_addresses(env.config, found_printers)
 
 
 @pppp.command("print-file")

--- a/cli/config.py
+++ b/cli/config.py
@@ -130,6 +130,37 @@ def load_config_from_api(auth_token, region, insecure):
     return config
 
 
+def update_printer_ip_addresses(config, printer_ips: list) -> list:
+    """
+    Checks configured printer IP addresses against the given set of addresses
+    and updates the IP address in the configuration if they differ.
+
+    Returns:
+    - List of names of updated printers, None upon an error
+    """
+    updated_printers = list()
+
+    with config.modify() as cfg:
+        if not cfg or not cfg.printers:
+            log.error("No printers configured. Run 'config login' or 'config import' to populate.")
+            return None
+
+        for p in cfg.printers:
+            prefix = f"  Printer [{p.p2p_duid}]:"
+            if p.p2p_duid in printer_ips:
+                if p.ip_addr != printer_ips[p.p2p_duid]:
+                    old_ip = p.ip_addr if p.ip_addr else "<empty>"
+                    log.info(f"{prefix} Updating IP address from {old_ip} to {printer_ips[p.p2p_duid]}")
+                    p.ip_addr = printer_ips[p.p2p_duid]
+                    updated_printers.append(p.name)
+                else:
+                    log.info(f"{prefix} IP address {p.ip_addr} is already up-to-date")
+            else:
+                log.warning(f"{prefix} No network response received, check connection!")
+
+    return updated_printers
+
+
 def attempt_config_upgrade(config, profile, insecure):
     path = config.config_path("default")
     data = json.load(path.open())

--- a/cli/config.py
+++ b/cli/config.py
@@ -27,7 +27,7 @@ class BaseConfigManager:
     def _borrow(self, value, write, default=None):
         pr = self.load(value, default)
         yield pr
-        if write:
+        if write and pr is not None:
             self.save(value, pr)
 
     @property

--- a/cli/pppp.py
+++ b/cli/pppp.py
@@ -30,6 +30,9 @@ def pppp_open(config, printer_index, timeout=None, dumpfile=None):
             log.critical(f"Printer number {printer_index} out of range, max printer number is {len(cfg.printers)-1} ")
         printer = cfg.printers[printer_index]
 
+        if not printer.ip_addr:
+            log.critical(f"Printer IP address not available")
+
         api = AnkerPPPPApi.open_lan(Duid.from_string(printer.p2p_duid), host=printer.ip_addr)
         _pppp_dumpfile(api, dumpfile)
 

--- a/libflagship/ppppapi.py
+++ b/libflagship/ppppapi.py
@@ -254,9 +254,11 @@ class AnkerPPPPBaseApi(Thread):
         return cls.open(duid, host, PPPP_WAN_PORT)
 
     @classmethod
-    def open_broadcast(cls):
+    def open_broadcast(cls, bind_addr=None):
         sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         sock.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
+        if bind_addr is not None:
+            sock.bind((bind_addr, 0))
         addr = ("255.255.255.255", PPPP_LAN_PORT)
         return cls(sock, duid=None, addr=addr)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ tqdm==4.65.0
 flask==2.3.2
 flask-sock==0.6.0
 user-agents==2.2.0
+ifaddr==0.2.0

--- a/static/ankersrv.js
+++ b/static/ankersrv.js
@@ -5,12 +5,17 @@ $(function () {
     $("#copyYear").text(new Date().getFullYear());
 
     /**
-     * Redirect page when modal dialog is shown
+     * Handle modal being shown
      */
-    var popupModal = document.getElementById("popupModal");
+    var popupModalDom = document.getElementById("popupModal");
 
-    popupModal.addEventListener("shown.bs.modal", function (e) {
-        window.location.href = $("#reload").data("href");
+    popupModalDom.addEventListener("shown.bs.modal", function (e) {
+        const trigger = e.relatedTarget;
+        const modalInner = $("#modal-inner");
+        modalInner.text(trigger.dataset.msg);
+        if (trigger.dataset.href) {
+            window.location.href = trigger.dataset.href;
+        }
     });
 
     /**

--- a/static/base.html
+++ b/static/base.html
@@ -30,7 +30,7 @@
             <div class="modal-dialog modal-dialog-centered">
                 <div class="modal-content">
                     <div class="modal-body">
-                        <p>Restarting ankerctl...</p>
+                        <p id="modal-inner"></p>
                         <div class="progress">
                             <div class="progress-bar progress-bar-striped progress-bar-animated w-100"
                                  role="progressbar"

--- a/static/tabs/setup.html
+++ b/static/tabs/setup.html
@@ -40,6 +40,34 @@
                     </div>
                 </form>
 
+                {% if printer %}
+                <form
+                    action="{{ url_for('app_api_ankerctl_config_update_ip_addresses') }}"
+                    method="POST"
+                    class="mb-3"
+                    id="config-update-printer-ips"
+                    data-bs-toggle="modal" data-bs-target="#popupModal"
+                    data-msg="Detecting printer IP addresses..."
+                >
+                    <div class="card">
+                        <div class="card">
+                            <div class="card-header fs-4">
+                                Update Printer IP Addresses
+                            </div>
+                            <div class="card-body">
+                                <p>
+                                    Make sure your printers are connected to your Wifi and
+                                    are located in the same network as Ankerctl.
+                                </p>
+                                <button class="btn btn-secondary submit" type="submit">
+                                    {{ macro.bi_icon("arrow-clockwise", "Update Printer IP Addresses") }}
+                                </button>
+                            </div>
+                        </div>
+                    </div>
+                </form>
+                {% endif %}
+
                 <div class="card">
                     <div class="card">
                         <div class="card-header fs-4">
@@ -52,6 +80,7 @@
                             </p>
                             <button id="reload" type="button" class="btn btn-danger"
                                     data-bs-toggle="modal" data-bs-target="#popupModal"
+                                    data-msg="Restarting ankerctl..."
                                     data-href="{{ url_for('app_api_ankerctl_server_reload') }}">
                                 {{ macro.bi_icon("bootstrap-reboot", "Reload Services") }}
                             </button>

--- a/web/__init__.py
+++ b/web/__init__.py
@@ -183,7 +183,7 @@ def app_api_ankerctl_config_update_ip_addresses():
     category = "info"
     url = url_for("app_root")
     config = app.config["config"]
-    found_printers = cli.pppp.pppp_find_printer_ip_addresses()
+    found_printers = dict(list(cli.pppp.pppp_find_printer_ip_addresses()))
 
     if found_printers:
         # update printer IP addresses

--- a/web/__init__.py
+++ b/web/__init__.py
@@ -135,6 +135,9 @@ def app_root():
         if cfg:
             anker_config = str(web.config.config_show(cfg))
             printer = cfg.printers[app.config["printer_index"]]
+            if not printer.ip_addr:
+                flash("Printer IP address is not set yet, please complete the setup...",
+                      "warning")
         else:
             anker_config = "No printers found, please load your login config..."
             printer = None

--- a/web/service/pppp.py
+++ b/web/service/pppp.py
@@ -36,6 +36,9 @@ class PPPPService(Service):
                 raise ServiceStoppedError("No config available")
             printer = cfg.printers[app.config["printer_index"]]
 
+        if not printer.ip_addr:
+            raise ServiceStoppedError("Printer IP address not available")
+
         api = AnkerPPPPAsyncApi.open_lan(Duid.from_string(printer.p2p_duid), host=printer.ip_addr)
         if app.config["pppp_dump"]:
             dumpfile = app.config["pppp_dump"]


### PR DESCRIPTION
This PR introduces the following features:
* CLI\
  `pppp lan-search` is extended by a flag `--store` which allows to update the already configured printers with the detected IP addresses.
* Web Interface\
   A new card is added in the Setup tab as shown below. It represents the GUI version of above `--store` option.
![Bildschirmfoto vom 2024-02-04 16-37-24](https://github.com/Ankermgmt/ankermake-m5-protocol/assets/8169178/f62cf30a-249e-4721-95a1-e74d1d3631bf)

Along with these changes an "internal" reload target address was introduced which does not remove pending flash messages (in contrast to the user-triggered reload). This is important when a success message shall be displayed by actions like uploading a new configuration file or updating printer IP addresses. If the user-triggered reload was being used, it would just display a success message for the reload, not for the actual action performed.