### PR TITLE
Add rudimentary WebRTC support via go2rtc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 __pycache__
 .DS_Store
 /settings.json
+.vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@
 __pycache__
 .DS_Store
 /settings.json
-.vscode/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.1] - 2024-01-15
+
+ - Fixes MQTT connection errors post AnkerMake Firmware Upgrades
+
 ## [1.0.0] - 2023-05-24
 
  - Version 1.0.0!

--- a/libflagship/mqtt.py
+++ b/libflagship/mqtt.py
@@ -89,7 +89,7 @@ class _MqttMsg:
     packet_num : u16le # maybe for fragmented messages?set to 1 for unfragmented messages.
     time       : u32le # `gettimeofday()` in whole seconds
     device_guid: bytes # device guid, as hex string
-    padding    : bytes = field(repr=False, kw_only=True, default='\x00' * 11) # padding bytes, allways zero
+    padding    : bytes # padding bytes, unknown usage
     data       : bytes # payload data
 
     @classmethod
@@ -105,7 +105,7 @@ class _MqttMsg:
         packet_num, p = u16le.parse(p)
         time, p = u32le.parse(p)
         device_guid, p = String.parse(p, 37)
-        padding, p = Zeroes.parse(p, 11)
+        padding, p = Bytes.parse(p, 11)
         data, p = Tail.parse(p)
         return cls(signature=signature, size=size, m3=m3, m4=m4, m5=m5, m6=m6, m7=m7, packet_type=packet_type, packet_num=packet_num, time=time, device_guid=device_guid, padding=padding, data=data), p
 
@@ -121,7 +121,7 @@ class _MqttMsg:
         p += u16le.pack(self.packet_num)
         p += u32le.pack(self.time)
         p += String.pack(self.device_guid, 37)
-        p += Zeroes.pack(self.padding, 11)
+        p += Bytes.pack(self.padding, 11)
         p += Tail.pack(self.data)
         return p
 

--- a/libflagship/mqttapi.py
+++ b/libflagship/mqttapi.py
@@ -51,7 +51,8 @@ class AnkerMQTTBaseClient:
         try:
             pkt, tail = MqttMsg.parse(msg.payload, key=self._key)
         except Exception as E:
-            log.error(f"Failed to decode mqtt message: {E}")
+            hexStr =' '.join([f'0x{byte:02x}' for byte in msg.payload])
+            log.error(f"Failed to decode mqtt message\n Exception: {E}\n Message : {hexStr}")
             return
 
         data = json.loads(pkt.data)

--- a/specification/mqtt.stf
+++ b/specification/mqtt.stf
@@ -50,8 +50,8 @@ struct _MqttMsg
     # device guid, as hex string
     device_guid: string<37>
 
-    # padding bytes, allways zero
-    padding:     zeroes<11>
+    # padding bytes, unknown usage
+    padding:     bytes<11>
 
     # payload data
     data: tail

--- a/web/__init__.py
+++ b/web/__init__.py
@@ -35,7 +35,7 @@ from user_agents import parse as user_agent_parse
 
 from libflagship import ROOT_DIR
 
-from web.lib.service import ServiceManager
+from web.lib.service import ServiceManager, RunState, ServiceStoppedError
 
 import web.config
 import web.platform

--- a/web/__init__.py
+++ b/web/__init__.py
@@ -116,8 +116,8 @@ def video_download():
     def generate():
         if not app.config["login"]:
             return
-        if not app.svc.running:
-            app.svc.run()
+        if not app.svc.get("videoqueue").running:
+            app.svc.get("videoqueue").run()
         for msg in app.svc.stream("videoqueue"):
             yield msg.data
 

--- a/web/__init__.py
+++ b/web/__init__.py
@@ -116,6 +116,8 @@ def video_download():
     def generate():
         if not app.config["login"]:
             return
+        if not app.svc.running:
+            app.svc.run()
         for msg in app.svc.stream("videoqueue"):
             yield msg.data
 

--- a/web/__init__.py
+++ b/web/__init__.py
@@ -116,8 +116,14 @@ def video_download():
     def generate():
         if not app.config["login"]:
             return
-        if not app.svc.get("videoqueue").running:
-            app.svc.get("videoqueue").run()
+        vq = app.svc.svcs.get("videoqueue")
+        if vq.state == RunState.Stopped:
+            try:
+                vq.start()
+                vq.await_ready()
+            except ServiceStoppedError:
+                log.error("VideoQueueService could not be started")
+                return
         for msg in app.svc.stream("videoqueue"):
             yield msg.data
 


### PR DESCRIPTION
I didn't explore too many options here, but I was able to get a restream via go2rtc/frigate by simply running the ServiceManager on the `/video` endpoint. Using this I am able to add a low latency camera feed to my Home Assistant dashboard.

EDIT:

Usage in Home Assistant:

![image](https://github.com/Ankermgmt/ankermake-m5-protocol/assets/44143748/d30c95c7-10ee-45e3-aba8-201c166f0e32)


## Using go2rtc
`go2rtc.yaml` (https://github.com/AlexxIT/go2rtc?tab=readme-ov-file#go2rtc-home-assistant-add-on)
```yaml
streams:
  Anker: 
    - ffmpeg:http://ankerctl-ip:4470/video
```


<details>
<summary>Alt: Frigate config</summary>

Note: Frigate just runs go2rtc

`config.yml`
```yaml
go2rtc:
  streams:
    Anker:
    - "ffmpeg:http://ankerctl-ip:4470/video"
```

</details>

## Lovelace Card (Home Assistant)
Add WebRTC integration from HACS (https://github.com/AlexxIT/WebRTC?tab=readme-ov-file#installation)

Use either `http://<go2rtc_ip>:1984` or `http://<frigate_ip>:1984` when configuring the integration, reboot and add a `Custom: WebRTC Camera` card to the dashboard:

```yaml
type: custom:webrtc-camera
url: Anker
```

PPPP has a tendency to crash after a while - I'm [working on a PR](https://github.com/anselor/ankermake-m5-protocol/pull/4) (which I've drafted into #160) that seems to be stable, but I'm still testing to make sure.